### PR TITLE
Optionally preserve blocks as Procs embedded in the sexps

### DIFF
--- a/lib/lispy.rb
+++ b/lib/lispy.rb
@@ -12,14 +12,19 @@ class Lispy
     @scope.last << [sym, args]
     if block
       # there is some simpler recursive way of doing this, will fix it shortly
-      @scope.last.last << []
-      @scope.push(@scope.last.last.last)
-      instance_exec(&block)
-      @scope.pop
+      if @remember_blocks_starting_with.include? sym
+        @scope.last.last << block
+      else
+        @scope.last.last << []
+        @scope.push(@scope.last.last.last)
+        instance_exec(&block)
+        @scope.pop
+      end
     end
   end
 
-  def to_data(&block)
+  def to_data(opts = {}, &block)
+    @remember_blocks_starting_with =  Array(opts[:retain_blocks_for])
     _(&block)
     @output
   end

--- a/test/lispy_test.rb
+++ b/test/lispy_test.rb
@@ -48,4 +48,28 @@ class LispyTest < Test::Unit::TestCase
 
     assert_equal expected, output
   end
+
+  def lispy_but_conditionally_preserving_procs
+    Lispy.new.to_data(:retain_blocks_for => [:Given, :When, :Then]) do
+      Scenario "My first awesome scenario" do
+        Given "teh shiznit" do
+          #shiznit
+        end
+
+        When "I do something" do
+          #komg.do_something
+        end
+
+        Then "this is pending"
+      end
+    end
+  end
+
+  def test_conditionally_preserving_procs
+    quasi_sexp = lispy_but_conditionally_preserving_procs
+    assert_equal :Scenario, quasi_sexp[0][0]
+    assert_equal "My first awesome scenario", quasi_sexp[0][1]
+    assert_equal :Given, quasi_sexp[0][2][0][0]
+    assert_instance_of Proc, quasi_sexp[0][2][0].last
+  end
 end


### PR DESCRIPTION
Adds the beginnings necessary to implement an instance_eval-based DSL using lispy.

Also see this gist for a better idea of what's going on: https://gist.github.com/1cf7ceb191dda447720b
